### PR TITLE
Implementing task

### DIFF
--- a/README.md
+++ b/README.md
@@ -105,6 +105,6 @@ const error = await randomPicAsyncResult.error; // -> Option<string | Error | un
 
 ## Roadmap
 
--   [ ✔ ] Add `Task`.
+-   [x] Add `Task`.
 -   [ ] Add `Option` tests.
 -   [ ] Research what other methods to implement.

--- a/README.md
+++ b/README.md
@@ -35,7 +35,7 @@ codebases.
 ### `crash`
 
 ```typescript
-import {crash} from "ga-ts";
+import { crash } from "ga-ts";
 
 const a = condition === true ? 1 : crash("This should never happen.");
 ```
@@ -43,13 +43,13 @@ const a = condition === true ? 1 : crash("This should never happen.");
 ### `Option`
 
 ```typescript
-import {Option, Some, None} from "ga-ts";
+import { Option, Some, None } from "ga-ts";
 
 const flagOption: Option<boolean> = [None, Some(false), Some(true)][Math.floor(Math.random() * 3)];
 
 if (!flagOption.some) {
     // The flag is not set, ask the user to set it.
-   return;
+    return;
 }
 
 // The flag is set, use it.
@@ -59,8 +59,8 @@ const flag = flagOption.value;
 ### `Result`
 
 ```typescript
-import {crash, AsyncResult, Ok, AsyncOk, Err} from "ga-ts";
-import {inspect} from "util";
+import { crash, AsyncResult, Ok, AsyncOk, Err } from "ga-ts";
+import { inspect } from "util";
 
 const firstOne: Result<number, never> = Ok(Math.random());
 const secondOne: AsyncResult<number, never> = AsyncOk(Promise.resolve(Math.random()));
@@ -83,7 +83,7 @@ const randomPicAsyncResult: AsyncResult<ArrayBuffer, string | Error | unknown> =
         const error = new Error(`Failed to fetch ${(error_ as Error)?.message || error_}`);
         await fetch("https://example.com/error", {
             method: "POST",
-            body: inspect(error, {depth: null}),
+            body: inspect(error, { depth: null }),
         });
         return error;
     }) // -> Async
@@ -105,6 +105,6 @@ const error = await randomPicAsyncResult.error; // -> Option<string | Error | un
 
 ## Roadmap
 
-- [ ] Add `Option` tests.
-- [ ] Add `Task`.
-- [ ] Research what other methods to implement.
+-   [ ✔ ] Add `Task`.
+-   [ ] Add `Option` tests.
+-   [ ] Research what other methods to implement.

--- a/src/crash.ts
+++ b/src/crash.ts
@@ -1,3 +1,6 @@
-export const crash = <T>(message: string): T => {
-    throw new Error(message);
+export const crash = <T>(e: unknown | string): T => {
+    if (e instanceof Error) {
+        throw e;
+    }
+    throw new Error(String(e));
 };

--- a/src/result.spec.ts
+++ b/src/result.spec.ts
@@ -183,6 +183,29 @@ describe("result.ts", () => {
 
             expect(result.error).toBe("Division by zero!");
         });
+        it("async task and function throws", async () => {
+            const division = ({
+                numerator,
+                denominator,
+            }: {
+                numerator: bigint;
+                denominator: bigint;
+            }) => numerator / denominator;
+
+            const start = AsyncOk(Promise.resolve({ numerator: 2n, denominator: 0n }));
+
+            const task = Task(division, (err: unknown) =>
+                err instanceof RangeError
+                    ? Err("Division by zero!")
+                    : crash<Result<never, string>>(err),
+            );
+
+            const result = start.flatMap(task);
+
+            const awaited = await result;
+
+            expect(awaited.error).toBe("Division by zero!");
+        });
         it("task and function returns", async () => {
             const division = ({
                 numerator,

--- a/src/result.spec.ts
+++ b/src/result.spec.ts
@@ -173,7 +173,11 @@ describe("result.ts", () => {
 
             const start = Ok({ numerator: 2n, denominator: 0n });
 
-            const task = Task(division, (err: unknown) => Err("Division by zero!"));
+            const task = Task(division, (err: unknown) =>
+                err instanceof RangeError
+                    ? Err("Division by zero!")
+                    : crash<Result<never, string>>(err),
+            );
 
             const result = start.flatMap(task);
 

--- a/src/result.spec.ts
+++ b/src/result.spec.ts
@@ -151,6 +151,40 @@ describe("result.ts", () => {
             expect(awaitedResult.error).toBeUndefined();
         });
     });
+    describe("Task", () => {
+        it("task and function throws", () => {
+            const division = ({
+                numerator,
+                denominator,
+            }: {
+                numerator: bigint;
+                denominator: bigint;
+            }) => numerator / denominator;
+
+            const start = Ok({ numerator: 2n, denominator: 0n });
+
+            const result = start.task(division, (err: unknown) => Err("Division by zero!"));
+
+            expect(result.error).toBe("Division by zero!");
+        });
+
+        it("task and function returns", async () => {
+            const division = ({
+                numerator,
+                denominator,
+            }: {
+                numerator: bigint;
+                denominator: bigint;
+            }) => numerator / denominator;
+
+            const start = Ok({ numerator: 2n, denominator: 2n });
+
+            const result = start.task(division, (err: unknown) => Err("Division by zero!"));
+
+            expect(result.value).toBe(1n);
+            expect(result.error).toBeUndefined();
+        });
+    });
 
     describe("other tests", () => {
         it("runs readme code", async () => {

--- a/src/result.spec.ts
+++ b/src/result.spec.ts
@@ -167,7 +167,6 @@ describe("result.ts", () => {
 
             expect(result.error).toBe("Division by zero!");
         });
-
         it("task and function returns", async () => {
             const division = ({
                 numerator,
@@ -183,6 +182,41 @@ describe("result.ts", () => {
 
             expect(result.value).toBe(1n);
             expect(result.error).toBeUndefined();
+        });
+        it("task and function returns when async function", async () => {
+            const asyncDivision = async ({
+                numerator,
+                denominator,
+            }: {
+                numerator: bigint;
+                denominator: bigint;
+            }) => Promise.resolve(numerator / denominator);
+
+            const start = Ok({ numerator: 2n, denominator: 2n });
+
+            const result = await start.task(asyncDivision, (err: unknown) =>
+                Err("Division by zero!"),
+            );
+
+            expect(result.value).toBe(1n);
+            expect(result.error).toBeUndefined();
+        });
+        it("task and function throws", async () => {
+            const asyncDivision = async ({
+                numerator,
+                denominator,
+            }: {
+                numerator: bigint;
+                denominator: bigint;
+            }) => Promise.resolve(numerator / denominator);
+
+            const start = Ok({ numerator: 2n, denominator: 0n });
+
+            const result = await start.task(asyncDivision, (err: unknown) =>
+                Err("Division by zero!"),
+            );
+
+            expect(result.error).toBe("Division by zero!");
         });
     });
 

--- a/src/result.ts
+++ b/src/result.ts
@@ -21,10 +21,6 @@ type BaseResult<T, E> = {
     attemptMap<R>(
         f: MapFn<T, R>,
     ): R extends Promise<infer R2> ? AsyncResult<R2, E | unknown> : Result<R, E | unknown>;
-    task<R, E2>(
-        f: MapFn<T, R>,
-        e: MapFn<unknown, Result<never, E2>>,
-    ): R extends Promise<infer R2> ? AsyncResult<R2, E2> : Result<R, E2>;
 };
 
 export type Result<T, E> = BaseResult<T, E>;
@@ -40,10 +36,6 @@ export type AsyncResult<T, E> = {
     attemptMap<R>(
         f: MapFn<T, R>,
     ): R extends Promise<infer R2> ? AsyncResult<R2, E | unknown> : AsyncResult<R, E | unknown>;
-    task<R, E2>(
-        f: MapFn<T, R>,
-        e: MapFn<unknown, Result<never, E2>>,
-    ): R extends Promise<infer R2> ? AsyncResult<R2, E2> : Result<R, E2>;
 } & Omit<BaseResult<T, E>, "value" | "error" | "map" | "mapError" | "flatMap"> &
     Promise<Result<T, E>>;
 
@@ -120,16 +112,6 @@ const promiseOfResultToAsyncResult = <T, E>(promise: Promise<Result<T, E>>): Asy
             return promiseOfResultToAsyncResult(mapped) as AsyncResult<R, E | unknown>;
         };
 
-    // @ts-ignore
-    promise.task = // Constrain the @ts-ignore to the bare minimum with this comment.
-        <R, E2>(f: MapFn<T, R>, e: MapFn<unknown, Result<never, E2>>): AsyncResult<R, E2> => {
-            const mapped = promise.then((resolved) => {
-                const mapped = resolved.task(f, e);
-                return Promise.resolve(mapped);
-            });
-            return promiseOfResultToAsyncResult(mapped) as AsyncResult<R, E2>;
-        };
-
     return promise as AsyncResult<T, E>;
 };
 
@@ -172,25 +154,6 @@ export const Ok = <T>(value: T): Result<T, never> => ({
             return Err(e) as Any;
         }
     },
-    task<R, E2>(
-        f: MapFn<T, R>,
-        errorHandler: MapFn<unknown, Result<never, E2>>,
-    ): R extends Promise<infer R2> ? AsyncResult<R2, E2> : Result<R, E2> {
-        try {
-            const newValue = f(value);
-
-            return (
-                newValue instanceof Promise //
-                    ? promiseOfResultToAsyncResult(
-                          newValue.then((resolved) => Ok(resolved)).catch((e) => errorHandler(e)),
-                      )
-                    : Ok(newValue)
-            ) as Any;
-        } catch (e) {
-            const errorHandled = errorHandler(e);
-            return errorHandled as Any;
-        }
-    },
 });
 
 export const Err = <E>(error: E): Result<never, E> => ({
@@ -210,7 +173,6 @@ export const Err = <E>(error: E): Result<never, E> => ({
     },
     flatMap: () => Err(error) as Any,
     attemptMap: () => Err(error) as Any,
-    task: () => Err(error) as Any,
 });
 
 export const AsyncOk = <T>(value: T | Promise<T>): AsyncResult<T, never> => {
@@ -229,4 +191,23 @@ export const AsyncErr = <E>(error: E | Promise<E>): AsyncResult<never, E> => {
     });
 
     return promiseOfResultToAsyncResult(resultPromise) as AsyncErr<E>;
+};
+
+export const Task = <T, E, R>(
+    f: MapFn<T, R>,
+    errorHandler: MapFn<unknown, Result<never, E>>,
+): ((v: T) => R extends Promise<infer R2> ? AsyncResult<R2, E> : Result<R, E>) => {
+    return (value: T) => {
+        try {
+            const newValue = f(value);
+
+            return newValue instanceof Promise //
+                ? promiseOfResultToAsyncResult(
+                      newValue.then((resolved) => Ok(resolved)).catch((e) => errorHandler(e)),
+                  )
+                : (Ok(newValue) as Any);
+        } catch (e) {
+            return errorHandler(e);
+        }
+    };
 };

--- a/src/result.ts
+++ b/src/result.ts
@@ -149,7 +149,9 @@ export const Ok = <T>(value: T): Result<T, never> => ({
         ) as Any;
     },
     mapError: () => Ok(value) as Any,
-    flatMap<T2, E2>(f: FlatMapFn<T, never, T2, E2>) {
+    flatMap<T2, E2>(
+        f: FlatMapFn<T, never, T2, E2>,
+    ): ReturnType<typeof f> extends Promise<T2> ? AsyncResult<T2, E2> : Result<T2, E2> {
         const result = f(value);
         return (result instanceof Promise ? promiseOfResultToAsyncResult(result) : result) as Any;
     },

--- a/src/result.ts
+++ b/src/result.ts
@@ -135,15 +135,11 @@ export const Ok = <T>(value: T): Result<T, never> => ({
         ) as Any;
     },
     mapError: () => Ok(value) as Any,
-    flatMap<T2, E2>(
-        f: FlatMapFnOrTask<T, never, T2, E2>,
-    ): ReturnType<typeof f> extends Promise<T2> ? AsyncResult<T2, E2> : Result<T2, E2> {
+    flatMap(f) {
         const result = f(value);
         return (result instanceof Promise ? promiseOfResultToAsyncResult(result) : result) as Any;
     },
-    attemptMap<R>(
-        f: MapFn<T, R>,
-    ): R extends Promise<infer R2> ? AsyncResult<R2, never> : Result<R, unknown> {
+    attemptMap(f) {
         try {
             const newValue = f(value);
 


### PR DESCRIPTION
Related to the issue #2 

Task is similar to attemptMap but instead of not handling the error and always getting a return type Result<T, unknown>, you pass a errorHandling function that handles the error, so you have control over the  error type.

